### PR TITLE
Ignore deployed configuration files (fixes #46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.bundle
 /vendor
 /.env
+/conf/httpd.conf
+/conf/httpd.conf.deployed


### PR DESCRIPTION
This adds configuration files created on deploy to `.gitignore`. I can't see a reason not to add this, so unless there are any objections I'll get this merged.