### PR TITLE
Improved nav spacing

### DIFF
--- a/2018/assets/sass/_mixins.scss
+++ b/2018/assets/sass/_mixins.scss
@@ -104,6 +104,16 @@ $prefixes: ("-webkit-","-moz-", "-o-", "-ms-", "");
   justify-content: $justify;
 }
 
+@mixin flex($values, $values2009: 0) {
+  -webkit-box-flex: $values2009;
+  -moz-box-flex: $values2009;
+  -webkit-box-flex: $values;
+  -moz-box-flex: $values;
+  -webkit-flex: $values;
+  -ms-flex: $values;
+  flex: $values;
+}
+
 @mixin high-dpi-image($path) {
   background-image: url("#{$path}.png");
 

--- a/2018/assets/sass/_nav.scss
+++ b/2018/assets/sass/_nav.scss
@@ -27,20 +27,23 @@
   margin: 0;
   padding: 0;
   list-style: none outside none;
+
+  // Flex layout to make whitespace between list items disappear.
+  @include flexbox();
+  @include flex-wrap(wrap);
+
   @media (min-width: $large_screen) {
     text-align: right;
+    @include flex-justify-content(flex-end);
   }
-
 }
 
 .nav li {
   display: inline-block;
   line-height: 0.6em;
-  &:last-child a {
-    &:after {
-      content: " ";
-    }
-  }
+
+  // Do not attempt to grow or shrink.
+  @include flex(0 0 auto);
 }
 
 .nav a {

--- a/2018/assets/sass/_nav.scss
+++ b/2018/assets/sass/_nav.scss
@@ -18,6 +18,7 @@
 
   & + small {
     display: block;
+    line-height: 1.4;
   }
 }
 

--- a/2018/assets/sass/main.scss
+++ b/2018/assets/sass/main.scss
@@ -191,6 +191,7 @@ textarea,
   padding: 1em 27px;
   position: relative;
   z-index: 10;
+
   @media (min-width: $large-screen) {
     position: absolute;
     left: 0;
@@ -199,6 +200,9 @@ textarea,
     position: fixed;
     top: 0;
     box-shadow: rgba(0,0,0, 0.1) 0 3px 20px;
+
+    @include flexbox();
+    @include flex-align-items(center);
   }
 }
 
@@ -218,14 +222,16 @@ textarea,
   @media (min-width: $large-screen) {
    width: 80%;
    float: left;
-   margin-top: 0.2em;
+   margin-top: 0;
   }
 }
 
 .nav {
-  margin-left: -0.6em;
+  margin: 0 -0.6em; // match horizontal padding on nav links
+  line-height: 0; // don't want inline-block list items to take up space
+
   @media (min-width: $large-screen) {
-    margin-left: 0;
+    margin: 0;
   }
 }
 

--- a/2018/assets/sass/main.scss
+++ b/2018/assets/sass/main.scss
@@ -188,14 +188,14 @@ textarea,
   @include clearfix();
   background-color: #fff;
   width: 100%;
-  padding: 27px;
+  padding: 1em 27px;
   position: relative;
   z-index: 10;
   @media (min-width: $large-screen) {
     position: absolute;
     left: 0;
     right: 0;
-    padding: 0.5em 80px;
+    padding: 1em 80px;
     position: fixed;
     top: 0;
     box-shadow: rgba(0,0,0, 0.1) 0 3px 20px;
@@ -213,10 +213,12 @@ textarea,
 
 .navigation-panel {
   width: 100%;
+  margin-top: 0.5em;
+
   @media (min-width: $large-screen) {
    width: 80%;
    float: left;
-   margin-top: 0.5em;
+   margin-top: 0.2em;
   }
 }
 


### PR DESCRIPTION
Some quick tweaks to vertical and horizontal spacing of nav items. They were bugging me 😉 

## 320px

![screen shot 2018-12-17 at 14 58 16](https://user-images.githubusercontent.com/739624/50094922-34c99500-020c-11e9-91ac-3be12c7bb141.png)

## 568px
![screen shot 2018-12-17 at 14 55 28](https://user-images.githubusercontent.com/739624/50094935-3abf7600-020c-11e9-888a-615cd68176a5.png)

## 800px
![screen shot 2018-12-17 at 14 55 58](https://user-images.githubusercontent.com/739624/50094943-3f842a00-020c-11e9-9de7-60ed2dc680a9.png)

## 900px
![screen shot 2018-12-17 at 14 56 05](https://user-images.githubusercontent.com/739624/50094948-4448de00-020c-11e9-8cd4-34e1c512c4c2.png)

## 1280px
![screen shot 2018-12-17 at 14 56 56](https://user-images.githubusercontent.com/739624/50094954-490d9200-020c-11e9-9e17-1152ff3f3b75.png)
