### PR TITLE
Change UKCOD to mySociety in site footer

### DIFF
--- a/2019/index.html
+++ b/2019/index.html
@@ -1099,7 +1099,7 @@ permalink: /
 
             <div class="col-sm-9 col-lg-6">
                 <div class="mysoc-footer__legal">
-                    <p>mySociety Limited is a project of UK Citizens Online Democracy, a registered charity in England and Wales. For full details visit <a href="https://www.mysociety.org">mysociety.org</a>.</p>
+                    <p><a href="https://www.mysociety.org">mySociety</a> is a registered charity in England and Wales (1076346) and a limited company (03277032). Through our trading subsidiary SocietyWorks (05798215) we also provide commercial services.</p>
                 </div>
             </div>
 


### PR DESCRIPTION
There's another reference in the text where we talk about our annual accounts (and also in the 2018 report), but that was the correct company name at the time so I'm leaving it in. Just changing the footer so that if we happen to base the next annual report on 2019's design, we don't end up with the wrong one.